### PR TITLE
Model returns an object instead of a pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,8 @@ The first argument is a function that returns a `Now`-computation. You
 don't have to fully understand `Now`. One of the things it does is to
 make it possible to create stateful behaviors. The model function will
 as input receive the output from the component that the view function
-returns. The result of the `Now`-computation must be a pair. The first
-value in the pair will be passed on to the view function and the
-second value will be the output of the component that `modelView`
+returns. The result of the `Now`-computation will be passed on to the 
+view function and will be the output of the component that `modelView` 
 returns. Here is how we use to create our counter component.
 
 ```ts
@@ -354,10 +353,10 @@ function* counterModel(
   const decrement = decrementClick.mapTo(-1);
   const changes = combine(increment, decrement);
   const count = yield sample(scan((n, m) => n + m, 0, changes));
-  return [{ count }, { count }];
+  return { count };
 }
 
-const counter = modelView(counterModel, counterView);
+const counter = modelView(counterModel, counterView)();
 ```
 
 Note that there is a cyclic dependency between the model and the view.

--- a/examples/continuous-time/README.md
+++ b/examples/continuous-time/README.md
@@ -1,9 +1,2 @@
 # Continuous time example
 
-Run with
-
-```
-webpack-dev-server --progress --colors
-```
-
-and go to [http://localhost:8080/](http://localhost:8080/)

--- a/examples/continuous-time/index.ts
+++ b/examples/continuous-time/index.ts
@@ -22,7 +22,7 @@ function model({ snapClick }: ViewOut): Now<any> {
     snapshot(time, snapClick)
   );
   const message = stepper("You've not clicked the button yet", msgFromClick);
-  return Now.of([{ time, message }, {}]);
+  return Now.of({time});
 }
 
 function* view({ time, message }: ToView): Iterator<Component<any>> {
@@ -33,6 +33,6 @@ function* view({ time, message }: ToView): Iterator<Component<any>> {
   return { snapClick };
 }
 
-const main = modelView<ToView, ViewOut, {}>(model, view)();
+const main = modelView<ToView, ViewOut>(model, view)();
 
 runComponent("#mount", main);

--- a/examples/counters/README.md
+++ b/examples/counters/README.md
@@ -1,9 +1,2 @@
 # Counters example
 
-Run with
-
-```
-webpack-dev-server --progress --colors
-```
-
-and go to [http://localhost:8080/](http://localhost:8080/)

--- a/examples/counters/src/index.ts
+++ b/examples/counters/src/index.ts
@@ -39,7 +39,7 @@ type FromModel = {
 const versionSelector = modelView<FromModel, FromView>(
   function ({ selectVersion }) {
     const selected = stepper("1", selectVersion);
-    return Now.of([{ selected }, { selected }] as [FromModel, FromModel]);
+    return Now.of({ selected });
   },
   function ({ selected }): Component {
     return div({ class: "btn-group" }, function* () {

--- a/examples/counters/src/version1.ts
+++ b/examples/counters/src/version1.ts
@@ -1,4 +1,5 @@
-import { elements } from "../../../src";
+import { Stream } from "@funkia/hareactive";
+import { elements, Component } from "../../../src";
 const { br, div, button } = elements;
 
 // Counter

--- a/examples/counters/src/version2.ts
+++ b/examples/counters/src/version2.ts
@@ -1,6 +1,6 @@
 import { combine } from "@funkia/jabz";
 import { Behavior, sample, scan, Stream } from "@funkia/hareactive";
-import { elements, modelView } from "../../../src";
+import { elements, modelView, Component } from "../../../src";
 const { br, div, button } = elements;
 
 type CounterModelInput = {
@@ -19,7 +19,7 @@ function* counterModel(
   const decrement = decrementClick.mapTo(-1);
   const changes = combine(increment, decrement);
   const count = yield sample(scan((n, m) => n + m, 0, changes));
-  return [{ count }, { count }];
+  return { count };
 }
 
 const counterView = ({ count }: CounterViewInput) => div([

--- a/examples/counters/src/version3.ts
+++ b/examples/counters/src/version3.ts
@@ -23,11 +23,11 @@ type CounterOutput = {
 
 function* counterModel(
   { incrementClick, decrementClick }: CounterModelInput
-): ModelReturn<CounterViewInput, CounterOutput> {
+): ModelReturn<CounterViewInput> {
   const increment = incrementClick.mapTo(1);
   const decrement = decrementClick.mapTo(-1);
   const count = yield sample(scan(add, 0, combine(increment, decrement)));
-  return [{ count }, { count }];
+  return { count };
 }
 
 const counterView = ({ count }: CounterViewInput) => div([
@@ -56,7 +56,7 @@ function* counterListModel({ addCounter, listOut }: ModelInput): Iterator<Now<an
     nextId: Stream<number> = yield sample(scanS(add, 2, addCounter.mapTo(1))),
     appendCounterFn = map((id) => (ids: number[]) => ids.concat([id]), nextId),
     counterIds = yield sample(scan(apply, [0], appendCounterFn));
-  return [{ counterIds }, {}];
+  return { counterIds };
 }
 
 function* counterListView({ sum, counterIds }: ViewInput): Iterator<Component<any>> {

--- a/examples/counters/src/version4.ts
+++ b/examples/counters/src/version4.ts
@@ -1,4 +1,3 @@
-import { IOValue } from "@funkia/jabz/dist";
 import { foldr, lift, flatten } from "@funkia/jabz";
 import {
   Now, sample, Behavior, scan, Stream, combine, map, combineList,
@@ -37,7 +36,7 @@ function* counterModel(
   const decrement = decrementClick.mapTo(-1);
   const deleteS = deleteClick.mapTo(id);
   const count = yield sample(scan(add, 0, combine(increment, decrement)));
-  return [{ count }, { count, deleteS }];
+  return { count, deleteS };
 }
 
 function counterView({ count }: CounterModelOut): Component<CounterModelInput> {
@@ -81,7 +80,7 @@ function* mainModel({ addCounter, listOut }: ToModel): Iterator<Now<any>> {
     combine(appendCounterFn, removeCounterIdFn);
   const counterIds =
     yield sample(scan(apply, [0, 1, 2], modifications));
-  return [{ counterIds, sum }, {}];
+  return { counterIds, sum };
 }
 
 function* mainView({ sum, counterIds }: ToView): Iterator<Component<any>> {
@@ -89,8 +88,7 @@ function* mainView({ sum, counterIds }: ToView): Iterator<Component<any>> {
   yield p(["Sum ", sum]);
   const { click: addCounter } = yield button({ class: "btn btn-primary" }, "Add counter");
   const { listOut } = yield ul(list((id) => counter(id), counterIds, "listOut"));
-
   return { addCounter, listOut };
 }
 
-export const counterList = modelView<ToView, ToModel, {}>(mainModel, mainView)();
+export const counterList = modelView<ToView, ToModel>(mainModel, mainView)();

--- a/examples/fahrenheit-celsius/README.md
+++ b/examples/fahrenheit-celsius/README.md
@@ -1,11 +1,3 @@
 # Fahrenheit celsius
 
 A converter between Fahrenheit and Celsius.
-
-Run with
-
-```
-webpack-dev-server --progress --colors
-```
-
-and go to [http://localhost:8080/](http://localhost:8080/)

--- a/examples/todo/src/Item.ts
+++ b/examples/todo/src/Item.ts
@@ -7,7 +7,7 @@ import {
 import { Component, modelView, elements } from "../../../src";
 const { div, li, input, label, button, checkbox } = elements;
 
-import { setItemIO, getItemIO } from "./index";
+import { setItemIO, getItemIO, removeItemIO } from "./index";
 
 const enter = 13;
 const esc = 27;
@@ -88,6 +88,10 @@ function* itemModel(
 
   const destroyItem = combine(deleteClicked, nameChange.filter((s) => s === ""));
   const destroyItemId = destroyItem.mapTo(id);
+
+  // Remove persist todo item
+  yield performStream(destroyItem.mapTo(removeItemIO(persistKey)));
+
   return {
     taskName: taskName_,
     isComplete,

--- a/examples/todo/src/Item.ts
+++ b/examples/todo/src/Item.ts
@@ -88,15 +88,16 @@ function* itemModel(
 
   const destroyItem = combine(deleteClicked, nameChange.filter((s) => s === ""));
   const destroyItemId = destroyItem.mapTo(id);
-  return [{
+  return {
     taskName: taskName_,
     isComplete,
     isEditing,
     newName,
-    focusInput: startEditing
-  }, {
-    id, destroyItemId, completed: isComplete
-  }] as [ToView, Output];
+    focusInput: startEditing,
+    id,
+    destroyItemId,
+    completed: isComplete
+  };
 }
 
 function itemView({ taskName, isComplete, isEditing, newName, focusInput }: ToView) {

--- a/examples/todo/src/TodoApp.ts
+++ b/examples/todo/src/TodoApp.ts
@@ -66,7 +66,7 @@ function* model({enterTodoS, toggleAll, clearCompleted, itemOutputs}: FromView) 
   }));
   const todoNames: Behavior<ItemParams[]> = yield sample(switcher(Behavior.of([]), restoredTodoNames));
   yield performStream(changes(todoNames).map((n) => setItemIO("todoList", n)));
-  return [{itemOutputs, todoNames, clearAll: clearCompleted, areAnyCompleted, toggleAll, areAllCompleted}, {}];
+  return {itemOutputs, todoNames, clearAll: clearCompleted, areAnyCompleted, toggleAll, areAllCompleted};
 }
 
 function view({itemOutputs, todoNames, areAnyCompleted, toggleAll, areAllCompleted}: ToView) {

--- a/examples/todo/src/index.ts
+++ b/examples/todo/src/index.ts
@@ -12,4 +12,8 @@ export const setItemIO = withEffects((key: string, value: any) => {
   localStorage.setItem(key, JSON.stringify(value));
 });
 
+export const removeItemIO = withEffects((key: string) => {
+  localStorage.removeItem(key);
+});
+
 runComponent("body", app);

--- a/test/component.spec.ts
+++ b/test/component.spec.ts
@@ -119,7 +119,7 @@ describe("modelView", () => {
   it("simple span component", () => {
     const c = modelView(
       function model(): Now<any> {
-        return Now.of([{}, {}] as [{}, {}]);
+        return Now.of({});
       },
       function view(): Component<any> {
         return span("World");
@@ -130,18 +130,16 @@ describe("modelView", () => {
     expect(dom.querySelector("span")).to.have.text("World");
   });
   it("passes argument to model", () => {
-    const pair = <A, B>(a: A, b: B): [A, B] => ([a, b]);
     const c = modelView(
-      ({ click }, n: number) => Now.of(pair({ n: Behavior.of(n) }, 12)),
+      ({ click }, n: number) => Now.of({ n: Behavior.of(n)}),
       ({ n }) => span(n)
     );
     const { dom } = testComponent(c(12));
     expect(dom.querySelector("span")).to.have.text(("12"));
   });
   it("passes argument to view", () => {
-    const pair = <A, B>(a: A, b: B): [A, B] => ([a, b]);
     const c = modelView(
-      ({ click }) => Now.of(pair({}, {})),
+      ({ click }) => Now.of({}),
       ({ }, n: number) => span(n)
     );
     const { dom } = testComponent(c(7));
@@ -153,7 +151,7 @@ describe("modelView", () => {
     const c = modelView(
       function model(args: FromView): Now<any> {
         fromView = args;
-        return Now.of([{}, {}] as [{}, {}]);
+        return Now.of({});
       }, (): Child<FromView> => [
         span("Hello"),
         input()
@@ -168,7 +166,7 @@ describe("modelView", () => {
       return;
     }
     const c = modelView(
-      function fooComp({ foo }: any): Now<any> { return Now.of([{}, {}] as [{}, {}]); },
+      function fooComp({ foo }: any): Now<any> { return Now.of({}); },
       function barView(): Component<any> { return Component.of({ bar: "no foo?" }); }
     )();
     assert.throws(() => {


### PR DESCRIPTION
After @dmitriz suggested removing the need to return a pair in the model function in [#31](https://github.com/funkia/turbine/pull/31#issuecomment-300400565), I have changed it, so that the output from a component is the same as what the model returns to the view.
```ts
function* model() {
  return {
    a: ...
    b: ...
  }
}

const {a, b} = runComponent(modelView(model, view));
```
