### PR TITLE
Remove Jabz as peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,16 +170,14 @@ single source of truth is lost.
 ## Installation
 
 ```sh
-npm install @funkia/turbine @funkia/hareactive @funkia/jabz
+npm install @funkia/turbine @funkia/hareactive
 ```
 
-[Hareactive](https://github.com/funkia/hareactive) and
-[Jabz](https://github.com/funkia/jabz) are peer dependencies that
-Turbine uses. Hareactive is the FRP library that we use and Jabz
-provides some very useful functional abstractions.
+[Hareactive](https://github.com/funkia/hareactive) is a peer
+dependency. It is the FRP library that that Turbine is based upon.
 
-Alternatively, for trying out Turbine you may want to see our [Turbine
-starter kit](https://github.com/funkia/turbine-starter).
+Alternatively, for quickly trying out Turbine you may want to see our
+[Turbine starter kit](https://github.com/funkia/turbine-starter).
 
 ## Examples
 
@@ -557,8 +555,7 @@ convenience.
 The API documentation is incomplete. See also the
 [examples](#examples), the [tutorial](#tutorial), the [Hareactive
 documentation](https://github.com/funkia/hareactive) and this tutorial
-about the
-[`IO`-monad](https://github.com/funkia/jabz/blob/master/docs/io-tutorial.md).
+about [IO](https://github.com/funkia/io).
 
 ### Component
 

--- a/examples/counters/src/index.ts
+++ b/examples/counters/src/index.ts
@@ -53,7 +53,7 @@ const versionSelector = modelView<FromModel, FromView>(
   }
 );
 
-const main = go(function* (): Iterator<Component<any>> {
+const main = go(function* () {
   const { selected } = yield versionSelector();
   const currentApp = selected.map((n: AppId) => numberToApp[n]);
   yield div(dynamic(currentApp));

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -1,12 +1,12 @@
-import {map, go} from "@funkia/jabz";
-import {runComponent, elements} from "../../src";
-const {span, input, div} = elements;
+import { map } from "@funkia/hareactive";
+import { runComponent, elements, go } from "../../src";
+const { span, input, div } = elements;
 
 const isValidEmail = (s: string) => s.match(/.+@.+\..+/i);
 
-const main = go(function*() {
+const main = go(function* () {
   yield span("Please enter an email address: ");
-  const {inputValue: email} = yield input();
+  const { inputValue: email } = yield input();
   const isValid = map(isValidEmail, email);
   yield div([
     "The address is ", map((b) => b ? "valid" : "invalid", isValid)

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@funkia/hareactive": "0.0.31",
-    "@funkia/jabz": "0.0.19"
+    "@funkia/hareactive": "0.0.31"
+  },
+  "dependencies": {
+    "@funkia/jabz": "0.0.22"
   },
   "bugs": {
     "url": "https://github.com/funkia/turbine/issues"
@@ -45,7 +47,6 @@
   "homepage": "https://github.com/funkia/turbine#readme",
   "devDependencies": {
     "@funkia/hareactive": "0.0.31",
-    "@funkia/jabz": "0.0.19",
     "@types/chai": "^3.4.35",
     "@types/chai-dom": "0.0.5",
     "@types/mocha": "^2.2.40",

--- a/src/component.ts
+++ b/src/component.ts
@@ -18,7 +18,7 @@ function isShowable(s: any): s is Showable {
 function fst<A, B>(a: [A, B]): A { return a[0]; }
 function snd<A, B>(a: [A, B]): B { return a[1]; }
 
-export function isGeneratorFunction<A, T>(fn: any): fn is ((a: A) => Iterator<T>) {
+export function isGeneratorFunction<A, T>(fn: any): fn is ((...a: any[]) => IterableIterator<T>) {
   return fn !== undefined
     && fn.constructor !== undefined
     && fn.constructor.name === "GeneratorFunction";
@@ -67,10 +67,7 @@ export function runComponent<A>(parent: Node | string, c: Child<A>): A {
 export function testComponent<A>(c: Component<A>): { out: A, dom: HTMLDivElement } {
   const dom = document.createElement("div");
   const out = runComponent(dom, c);
-  return {
-    out,
-    dom
-  };
+  return { out, dom };
 }
 
 export function isComponent(c: any): c is Component<any> {
@@ -181,7 +178,7 @@ export type Model1<V, M, A> = (v: V, a: A) => ModelReturn<M>;
 export type View<M, V> = ((m: M) => Child<V>) | ((m: M) => Iterator<Component<any>>);
 export type View1<M, V, A> = ((m: M, a: A) => Child<V>) | ((m: M, a: A) => Iterator<Component<any>>);
 
-export function modelView<M extends ReactivesObject, V = {}>(
+export function modelView<M extends ReactivesObject, V>(
   model: Model<V, M>, view: View<M, V>, toViewReactiveNames?: string[]
 ): () => Component<M>;
 export function modelView<M extends ReactivesObject, V, A>(
@@ -191,7 +188,7 @@ export function modelView<M extends ReactivesObject, V>(
   model: any, view: any, toViewReactiveNames?: string[]
 ): (...args: any[]) => Component<M> {
   const m = isGeneratorFunction<V, any>(model) ? fgo(model) : model;
-  const v = isGeneratorFunction<any, any>(view) ? fgo(view) : (...as: any[]) => toComponent(view(...as));
+  const v: any = isGeneratorFunction<any, any>(view) ? fgo(view) : (...as: any[]) => toComponent(view(...as));
   return (...args: any[]) => new Component<M>((parent: Node) => new MfixNow<M>(
     (bs) => v(bs, ...args)
       .content(parent)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
+export { fgo, go } from "@funkia/jabz";
 export * from "./component";
 export * from "./dom-builder";
 import * as elements from "./elements";
-export {elements};
+export { elements };

--- a/test/component.spec.ts
+++ b/test/component.spec.ts
@@ -2,7 +2,10 @@ import { assert, use, expect } from "chai";
 import * as chaiDom from "chai-dom";
 use(chaiDom);
 import { fgo } from "@funkia/jabz";
-import { Behavior, isBehavior, sinkBehavior, placeholder, Now, publish, fromFunction } from "@funkia/hareactive";
+import {
+  Behavior, Stream, isBehavior, sinkBehavior, placeholder, Now,
+  publish, fromFunction
+} from "@funkia/hareactive";
 import * as fakeRaf from "fake-raf";
 
 import {
@@ -25,7 +28,7 @@ describe("component specs", () => {
       expect(dom).to.have.text("world");
     });
     it("converts an array of components to component", () => {
-      const component = toComponent([span("Hello"), div("There"), button({output: {click: "click"}}, "Click me")]);
+      const component = toComponent([span("Hello"), div("There"), button({ output: { click: "click" } }, "Click me")]);
       const { dom, out } = testComponent(component);
 
       expect(out).to.have.property("click");
@@ -131,11 +134,15 @@ describe("modelView", () => {
   });
   it("passes argument to model", () => {
     const c = modelView(
-      ({ click }, n: number) => Now.of({ n: Behavior.of(n)}),
+      ({ click }: { click: Stream<any> }, n: number) => Now.of({ n: Behavior.of(n) }),
       ({ n }) => span(n)
     );
     const { dom } = testComponent(c(12));
     expect(dom.querySelector("span")).to.have.text(("12"));
+    const test = modelView(
+      ({ inputValue }) => Now.of({ foo: Behavior.of(12) }),
+      ({ foo }) => input()
+    );
   });
   it("passes argument to view", () => {
     const c = modelView(
@@ -155,7 +162,7 @@ describe("modelView", () => {
         return Now.of({});
       }, (): Child<FromView> => [
         span("Hello"),
-        input({output: {inputValue: "inputValue"}})
+        input({ output: { inputValue: "inputValue" } })
       ])();
     const { dom } = testComponent(c);
     expect(dom.querySelector("span")).to.exist;


### PR DESCRIPTION
* Remove Jabz as a peer depenceny
* Don't mention it in the readme
* Reexport `go` and `fgo` from Jabz as they are the only functions from Jabz that are essential for Turbine users.

I've also moved IO from Jabz into a [seperate library](https://github.com/funkia/io). This is to make it possible for people to use IO in Turbine without having to look at Jabz.

cc: @limemloh @jayrbolton