### PR TITLE
Add explicit output

### DIFF
--- a/examples/todo/src/TodoApp.ts
+++ b/examples/todo/src/TodoApp.ts
@@ -3,7 +3,7 @@ import {
   Behavior, scan, map, sample, snapshot, Stream, switchStream, combine,
   Future, switcher, plan, performStream, changes, snapshotWith, scanCombine, moment
 } from "@funkia/hareactive";
-import {modelView, elements, list} from "../../../src";
+import {modelView, elements, list, output} from "../../../src";
 const {h1, p, header, footer, section, checkbox, ul, label} = elements;
 import { Router } from "@funkia/rudolph";
 
@@ -52,10 +52,10 @@ function ListModel<A, B>({ prependItemS, removeKeyListS, itemToKey, initial }: L
   ], initial));
 }
 
-function* model({enterTodoS, toggleAll, clearCompleted, itemOutputs}: FromView) {
+function* model({addItem, toggleAll, clearCompleted, itemOutputs}: FromView) {
   const nextId = itemOutputs.map((outs) => outs.reduce((maxId, {id}) => Math.max(maxId, id), 0) + 1);
 
-  const newTodoS = snapshotWith((name, id) => ({name, id}), nextId, enterTodoS);
+  const newTodoS = snapshotWith((name, id) => ({name, id}), nextId, addItem);
   const deleteS = switchStream(itemOutputs.map((list) => combine(...list.map((o) => o.destroyItemId))));
   const completedIds = getCompletedIds(itemOutputs);
 
@@ -90,7 +90,7 @@ function view({itemOutputs, todoNames, areAnyCompleted, toggleAll, areAllComplet
     section({class: "todoapp"}, [
       header({class: "header"}, [
         h1("todos"),
-        todoInput
+        output({addItem: "addItem"}, todoInput)
       ]),
       section({
         class: "main",
@@ -108,7 +108,10 @@ function view({itemOutputs, todoNames, areAnyCompleted, toggleAll, areAllComplet
           list((n) => item({toggleAll, router, ...n}), todoNames, "itemOutputs", (o) => o.id)
         )
       ]),
-      todoFooter({todosB: itemOutputs, areAnyCompleted, router})
+      output(
+        {clearCompleted: "clearCompleted"},
+        todoFooter({todosB: itemOutputs, areAnyCompleted, router})
+      )
     ]),
     footer({class: "info"}, [
       p("Double-click to edit a todo"),

--- a/examples/todo/src/TodoFooter.ts
+++ b/examples/todo/src/TodoFooter.ts
@@ -9,7 +9,8 @@ import { Output as ItemOut } from "./Item";
 
 export type Params = {
   todosB: Behavior<ItemOut[]>,
-  areAnyCompleted: Behavior<boolean>
+  areAnyCompleted: Behavior<boolean>,
+  router: Router
 };
 
 export type Out = {
@@ -65,8 +66,6 @@ const view = ({ }, { todosB, areAnyCompleted }: Params) => {
   ]);
 };
 
-const todoFooter = modelView(model, view);
+const todoFooter = modelView<Out, FromView, Params>(model, view);
 
 export default todoFooter;
-
-

--- a/examples/todo/src/TodoInput.ts
+++ b/examples/todo/src/TodoInput.ts
@@ -15,15 +15,15 @@ type Looped = {
 };
 
 export type Out = {
-  enterTodoS: Stream<string>
+  addItem: Stream<string>
 };
 
 function* model({ enterPressed, value }) {
-  const enterTodoS = snapshot(value, enterPressed).filter(isValidValue);
+  const addItem = snapshot(value, enterPressed).filter(isValidValue);
   const clearedValue = yield sample(stepper(
     "", combine(changes(value), enterPressed.mapTo(""))
   ));
-  return { enterTodoS, clearedValue };
+  return { addItem, clearedValue };
 }
 
 const view = ({ clearedValue }) => input({
@@ -35,4 +35,4 @@ const view = ({ clearedValue }) => input({
   }
 }).map((output) => ({ enterPressed: output.keyup.filter(isEnterKey), ...output }));
 
-export default modelView(model, view)();
+export default modelView<Out, any>(model, view)();

--- a/src/dom-builder.ts
+++ b/src/dom-builder.ts
@@ -6,7 +6,7 @@ import {
   Component, runComponent, viewObserve, Showable, Child, isChild,
   toComponent
 } from "./component";
-import { id, rename, mergeDeep, assign } from "./utils";
+import { id, mergeDeep, assign, copyRemaps } from "./utils";
 
 export type EventName = keyof HTMLElementEventMap;
 
@@ -85,7 +85,7 @@ export type DefaultOutput = {
 };
 
 export type InitialOutput<P extends InitialProperties> =
-  OutputStream<(P & {streams: {}})["streams"]> & BehaviorOutput<(P & {behaviors: {}})["behaviors"]> & DefaultOutput;
+  OutputStream<(P & { streams: {} })["streams"]> & BehaviorOutput<(P & { behaviors: {} })["behaviors"]> & DefaultOutput;
 
 // An array of names of all DOM events
 export const allDomEvents: EventName[] =
@@ -158,11 +158,27 @@ function handleCustom(
 }
 
 class DomComponent<A> extends Component<A> {
+  child: Component<any> | undefined;
   constructor(
     private tagName: string,
-    private props?: Properties<A> & {output?: OutputNames<A>},
-    private children?: Child
-  ) { super(); }
+    private props?: Properties<A> & { output?: OutputNames<A> },
+    child?: Child
+  ) {
+    super();
+    if (props.output !== undefined) {
+      this.explicitOutput = Object.keys(props.output);
+    }
+    if (child !== undefined) {
+      this.child = toComponent(child);
+      if (this.child.explicitOutput !== undefined) {
+        if (this.explicitOutput === undefined) {
+          this.explicitOutput = this.child.explicitOutput;
+        } else {
+          this.explicitOutput = this.explicitOutput.concat(this.child.explicitOutput);
+        }
+      }
+    }
+  }
   run(parent: Node): A {
     let output: any = {};
     const elm = document.createElement(this.tagName);
@@ -186,16 +202,7 @@ class DomComponent<A> extends Component<A> {
           let a: Behavior<any> = undefined;
           const initial = initialFn(elm);
           Object.defineProperty(output, name, {
-            enumerable: false,
-            configurable: true,
-            set: function<A>(value: A): void {
-              Object.defineProperty(output, name, {
-                enumerable: true,
-                get: (): A => {
-                  return value;
-                }
-              });
-            },
+            enumerable: true,
             get: (): Behavior<any> => {
               if (a === undefined) {
                 a = behaviorFromEvent(elm, evt, initial, extractor);
@@ -211,16 +218,7 @@ class DomComponent<A> extends Component<A> {
           let a: Stream<any> = undefined;
           if (output[name] === undefined) {
             Object.defineProperty(output, name, {
-              enumerable: false,
-              configurable: true,
-              set: function<A>(value: A): void {
-                Object.defineProperty(output, name, {
-                  enumerable: true,
-                  get: (): A => {
-                    return value;
-                  }
-                });
-              },
+              enumerable: true,
               get: (): Stream<any> => {
                 if (a === undefined) {
                   a = streamFromEvent(elm, evt, extractor);
@@ -233,12 +231,12 @@ class DomComponent<A> extends Component<A> {
       }
     }
     parent.appendChild(elm);
-    if (this.children !== undefined) {
-      const childOutput = runComponent(elm, toComponent(this.children));
-      assign(output, childOutput);
-    }
     if (this.props.output !== undefined) {
-      rename(output, this.props.output);
+      output = copyRemaps(this.props.output, output);
+    }
+    if (this.child !== undefined) {
+      const childOutput = runComponent(elm, toComponent(this.child));
+      assign(output, childOutput);
     }
     return output;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,15 +61,15 @@ export function mergeDeep(...objects: any[]): any { // .length of function is 2
   return result;
 }
 
-// Note this function mutates `source`
-export function rename(
-  source: { [key: string]: any },
-  renames: { [name: string]: string }
-): void {
-  for (const newName of Object.keys(renames)) {
-    const name = renames[newName];
-    source[newName] = source[name];
+export function copyRemaps(
+  remap: Record<string, string>,
+  source: Record<string, any>
+): Record<string, any> {
+  const output = {};
+  for (let key in remap) {
+    output[key] = source[remap[key]];
   }
+  return output;
 }
 
 export function id<A>(a: A): A { return a; }

--- a/test/dom-builder.spec.ts
+++ b/test/dom-builder.spec.ts
@@ -9,7 +9,7 @@ import { id } from "../src/utils";
 import { testComponent, element, Component, elements } from "../src";
 const { button, div } = elements;
 
-describe("dom-builder: e()", () => {
+describe("dom-builder", () => {
 
   it("basic DOM elements", () => {
     const spanFac = element("span");
@@ -52,7 +52,7 @@ describe("dom-builder: e()", () => {
   });
 
   describe("output", () => {
-    it("passes parent output through", () => {
+    it("passes explicit child output through", () => {
       const c = div(button({ output: { buttonClick: "click" } }));
       const { out } = testComponent(c);
       assert(isStream(out.buttonClick));
@@ -73,12 +73,19 @@ describe("dom-builder: e()", () => {
       assert(isStream(out.fooClick));
       assert(isStream(out.barClick));
     });
-    it("merges own output with child output", () => {
+    it("merges own output with explicit output in child array", () => {
       const btn = button({ output: { fooClick: "click" } }, "Click me");
-      const myDiv = div({output: {divClick: "click"}}, [btn]);
+      const myDiv = div({ output: { divClick: "click" } }, [btn]);
       const { out } = testComponent(myDiv);
       assert(isStream(out.divClick));
       assert(isStream(out.fooClick));
+    });
+    it("merges all output from non-array child", () => {
+      const child = Component.of({ bar: 1 });
+      const myDiv = div({ output: { divClick: "click" } }, child);
+      const { out } = testComponent(myDiv);
+      assert(isStream(out.divClick));
+      assert.strictEqual(out.bar, 1);
     });
   });
 
@@ -192,7 +199,7 @@ describe("dom-builder: e()", () => {
     it("nested", () => {
       const spanFac = element("span");
       const h1Fac = element("h1");
-      const span = h1Fac(spanFac("Test"));
+      const span = h1Fac([spanFac("Test")]);
       const { dom, out } = testComponent(span);
       expect(dom.querySelector("h1")).to.have.length(1);
       expect(dom.querySelector("h1")).to.contain("span");
@@ -209,7 +216,7 @@ describe("dom-builder: e()", () => {
       });
       const spanC = spanFac();
       const { dom } = testComponent(spanC);
-      expect(dom.querySelector("span")).to.have.attribute("style", "background-color: red;")
+      expect(dom.querySelector("span")).to.have.attribute("style", "background-color: red;");
     });
     it("override style", () => {
       const spanFac = element("span", {

--- a/tslint.json
+++ b/tslint.json
@@ -13,7 +13,6 @@
     ],
     "curly": true,
     "eofline": true,
-    "forin": true,
     "indent": [
       true,
       "spaces"
@@ -50,7 +49,6 @@
     "no-shadowed-variable": true,
     "no-string-literal": true,
     "no-trailing-whitespace": true,
-    "no-unused-expression": true,
     "no-unused-variable": [true, {"ignore-pattern": "^_"}],
     "no-var-keyword": true,
     "no-var-requires": true,


### PR DESCRIPTION
This PR adds a `output` method and an `output` function.

```ts
output({ newName: originalName }, component);
component.output({ newName: originalName });
```

The mehods works similairly to the `output` property in the HTML element components. They take a component whose output is an object and returns a new component which only outputs the named properties under their new name.

Output created with `output` is considered _explicit_. When the output from an array of components is merged _only_ explicit output is includeded.

```ts
div({ ... }, [
  fooComponent, // output from this component is not included
  output({ foo: "bar" }, barComponent) // this components `bar` property is included with the name `foo`
]);
```

Theses changes have a few important benefits:

* It is easy to rename the output of custom components.
* Since only explicitly mentioned output is combined when an array is turned into a component the risk of collisions and accidental inclusion of output is removed.

Here is an example where a custom component `counter` is included three times. The custom component has the output `{ count: Stream<number> }`.

```ts
const listOfCounters = div([
  counter(0), // `output` is not used here so the `count` output will not be used
  counter(0).output({ count1: "count" }), // this custom components output is easily renamed
  counter(0).output({ count2: "count" }) // renaming avoids a collision
]);
```

Output created by specifying the `output` property to HTML components is marked explicit.

```ts
div([
  // The component created below will have `btnClick` as explicit output
  button({ output: { btnClick: "click" }}, "Click me"),
 // the above is equivalent to the following
  button("Click me").output({ btnClick: "click" })
]);
```