### PR TITLE
Add unknown properties as attribute

### DIFF
--- a/src/dom-builder.ts
+++ b/src/dom-builder.ts
@@ -249,7 +249,19 @@ function handleEntryClass(desc: string, elm: HTMLElement): void {
   });
 }
 
-const propKeywords = ["style", "attrs", "props", "class", "actionDefinitions", "actions", "setters", "entry", "behaviors", "streams", "output"];
+const propKeywords = new Set([
+  "style",
+  "attrs",
+  "props",
+  "class",
+  "actionDefinitions",
+  "actions",
+  "setters",
+  "entry",
+  "behaviors",
+  "streams",
+  "output"
+]);
 export function handleProps<A>(
   props: Properties<A> & { output?: OutputNames<A> },
   elm: HTMLElement
@@ -258,7 +270,7 @@ export function handleProps<A>(
 
   let attrs = Object.assign({}, props.attrs);
   for (const [key, value] of Object.entries(props)) {
-    if (!propKeywords.includes(key) && attrs[key] === undefined) {
+    if (!propKeywords.has(key) && attrs[key] === undefined) {
       attrs[key] = value;
     }
   }

--- a/test/dom-builder.spec.ts
+++ b/test/dom-builder.spec.ts
@@ -296,6 +296,14 @@ describe("dom-builder", () => {
       publish(false, checkedB);
       expect(aElm).to.not.have.attribute("checked");
     });
+    it("sets attributes from root", () => {
+      const hrefB = sinkBehavior("/foo");
+      const { dom } = testComponent(element("a", { href: hrefB })());
+      const aElm = dom.firstChild;
+      expect(aElm).to.have.attribute("href", "/foo");
+      publish("/bar", hrefB);
+      expect(aElm).to.have.attribute("href", "/bar");
+    });
   });
 
   describe("properties", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "strictPropertyInitialization": false,
     "noStrictGenericChecks": true,
-    "lib": ["dom", "es2016.array.include", "es2015"]
+    "lib": ["dom", "es2017"]
   },
   "include": ["src/**/*", "test/**/*", "examples/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
We need to set attributes from `props.attrs` & attributes in `props` before we set behaviors.
Simple way of doing it is looping over the keys in `props`, check against a list of known keywords, then reuse previous code.