### PR TITLE
updated webpackbin links to codesandbox.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ making it even better.
 
 ### Email validator
 
-[See the example live here](https://www.webpackbin.com/bins/-KkMDZ7CT-2FIx0SqEJd).
+[See the example live here](https://codesandbox.io/s/jv74x1jny3?module=%2Fsrc%2Findex.js).
 
 ```js
 const isValidEmail = (s: string) => s.match(/.+@.+\..+/i);
@@ -63,7 +63,7 @@ runComponent("#mount", main);
 
 ### Counter
 
-[See the example live here](https://www.webpackbin.com/bins/-KkyWM1zctrimQqzrScj).
+[See the example live here](https://codesandbox.io/s/k9y0po3vv3?module=%2Fsrc%2Findex.js).
 
 ```js
 const counterModel = fgo(function* ({ incrementClick, decrementClick }) {


### PR DESCRIPTION
As you may already know, webpackbin has moved to codesandbox.io, so I moved the code over there and updated the links.

It'd be better if I could link to a specific version of the code on a sandbox (so it'd be immune to accidental modifications I hopefully won't make), but I wasn't able to figure that out in codesandbox.io. If you wanted to fork the code I created and provide your own links (so you have more control), that works too.