### PR TITLE
Rename inputValue to value

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const isValidEmail = (s: string) => /.+@.+\..+/i.test(s);
 
 function* main() {
   yield span("Please enter an email address: ");
-  const { inputValue: email } = yield input();
+  const { value: email } = yield value();
   const isValid = email.map(isValidEmail);
   yield div([
     "The address is ",
@@ -437,7 +437,7 @@ Let's see what an input element actually looks like.
 ```ts
 const usernameInput = input({
   attrs: { placeholder: "Username" }
-}).output({ username: "inputValue" });
+}).output({ username: "value" });
 ```
 
 Here `usernameInput` has the type
@@ -447,7 +447,7 @@ Component<{username: Behavior<string>}>
 ```
 
 An `input` element produces a string valued behavior named
-`inputValue` that contains the current content of the `input` element.
+`value` that contains the current content of the `input` element.
 We then give the `input` function an object `output` that tells it to
 output the behavior with the property `username`.
 
@@ -582,8 +582,8 @@ the text in the two input fields.
 
 ```typescript
 input({ attrs: { placeholder: "foo" } }).chain(
-  ({ inputValue: aValue }) => input().chain(
-    ({ inputValue: bValue }) => {
+  ({ value: aValue }) => input().chain(
+    ({ value: bValue }) => {
       const concatenated = lift((a, b) => a + b, aValue, bValue);
       return span(["Concatenated text: ", concatenated]).mapTo({concatenated});
     }
@@ -597,8 +597,8 @@ generators.
 
 ```typescript
 go(function*() {
-  const {inputValue: aValue} = yield input();
-  const {inputValue: bValue} = yield input();
+  const {value: aValue} = yield input();
+  const {value: bValue} = yield input();
   const concatenated = lift((a, b) => a + b, aValue, bValue);
   yield span(["Concatenated text: ", concatenated]);
   return {concatenated};
@@ -661,10 +661,10 @@ a function from `A` to `B` over the component and get a new component
 whose output is of type `B`.
 
 In the example below `input` creates a component with an object as
-output. The object contains a behavior named `inputValue`. The
+output. The object contains a behavior named `value`. The
 function given to `map` receives the output from the component. 
 
-We then call `map` on the behavior `inputValue` and take the length of
+We then call `map` on the behavior `value` and take the length of
 the string. The result is that `usernameInput` has the type
 `Component<Behavior<number>>` because it's mapped output is a
 number-valued behavior whose value is the current length of the text
@@ -673,7 +673,7 @@ in the input element.
 ```ts
 const usernameInput =
   input({class: "form-control"})
-    .map((output) => output.inputValue.map((s) => s.length));
+    .map((output) => output.value.map((s) => s.length));
 ```
 
 #### `Component#chain`
@@ -702,7 +702,7 @@ component that works like this:
 Here is an example.
 
 ```typescript
-input().chain((inputOutput) => span(inputOutput.inputValue));
+input().chain((inputOutput) => span(inputOutput.value));
 ```
 
 The above example boils down to this:
@@ -710,8 +710,8 @@ The above example boils down to this:
 ```typescript
 Create input component   Create span component with text content
   ↓                             ↓
-input().chain((inputOutput) => span(inputOutput.inputValue));
-                   ↑                                ↑
+input().chain((inputOutput) => span(inputOutput.value));
+                   ↑                              ↑
       Output from input-element       Behavior of text in input-element
 ```
 

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -11,7 +11,7 @@ const model = ({ email }: { email: Behavior<string> }) => {
 
 const view = ({ isValid }: { isValid: Behavior<boolean> }) => [
   span("Please enter an email address: "),
-  input().output({ email: "inputValue" }),
+  input().output({ email: "value" }),
   div(["The address is ", map((b) => (b ? "valid" : "invalid"), isValid)])
 ];
 

--- a/examples/todo/src/TodoInput.ts
+++ b/examples/todo/src/TodoInput.ts
@@ -43,7 +43,7 @@ const view = ({ clearedValue }) =>
       placeholder: "What needs to be done?"
     }
   }).output((o) => ({
-    value: o.inputValue,
+    value: o.value,
     enterPressed: o.keyup.filter(isEnterKey)
   }));
 

--- a/examples/zip-codes/index.ts
+++ b/examples/zip-codes/index.ts
@@ -98,7 +98,7 @@ const view = ({ status }: ToView) => [
   span("Please type a valid US zip code: "),
   input({
     props: { placeholder: "Zip code" }
-  }).output({ zipCode: "inputValue" }),
+  }).output({ zipCode: "value" }),
   br,
   span(status)
 ];

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -10,7 +10,7 @@ export const input = element("input", {
     focus: (elm: HTMLElement): void => elm.focus()
   },
   behaviors: {
-    inputValue: behaviorDescription(
+    value: behaviorDescription(
       "input",
       (evt: any) => evt.target.value as string,
       (elm: any) => elm.value as string
@@ -20,7 +20,7 @@ export const input = element("input", {
 
 export const textarea = element("textarea", {
   behaviors: {
-    inputValue: behaviorDescription(
+    value: behaviorDescription(
       "input",
       (evt: any) => evt.target.value as string,
       (elm: any) => elm.value as string

--- a/test/component.spec.ts
+++ b/test/component.spec.ts
@@ -190,7 +190,7 @@ describe("component specs", () => {
       const comp = loop(
         fgo(function*({ name }: Looped): IterableIterator<Component<any, any>> {
           yield div(name);
-          ({ inputValue: name } = yield input({ props: { value: "Foo" } }));
+          ({ value: name } = yield input({ props: { value: "Foo" } }));
           return { name };
         })
       );
@@ -203,7 +203,7 @@ describe("component specs", () => {
     //     name
     //   }: Looped): IterableIterator<Component<any, any>> {
     //     yield div(name);
-    //     ({ inputValue: name } = yield input({ props: { value: "Foo" } }));
+    //     ({ value: name } = yield input({ props: { value: "Foo" } }));
     //     return { name };
     //   });
     // });
@@ -216,7 +216,7 @@ describe("component specs", () => {
         }: Looped): IterableIterator<Component<any, any>> {
           yield div(name);
           destroyed.subscribe((b) => (toplevel = b));
-          ({ inputValue: name } = yield input({ props: { value: "Foo" } }));
+          ({ value: name } = yield input({ props: { value: "Foo" } }));
           return { name };
         })
       );
@@ -264,7 +264,7 @@ describe("modelView", () => {
     expect(dom.querySelector("span")).to.have.text("7");
   });
   it("view is function returning array of components", () => {
-    type FromView = { inputValue: H.Behavior<any> };
+    type FromView = { value: H.Behavior<any> };
     let fromView: FromView;
     const c = modelView(
       function model(args: FromView): H.Now<any> {
@@ -273,13 +273,13 @@ describe("modelView", () => {
       },
       (): Child<FromView> => [
         span("Hello"),
-        input().output({ inputValue: "inputValue" })
+        input().output({ value: "value" })
       ]
     )();
     const { dom } = testComponent(c);
     expect(dom.querySelector("span")).to.exist;
     expect(dom.querySelector("span")).to.have.text("Hello");
-    assert(H.isBehavior(fromView!.inputValue));
+    assert(H.isBehavior(fromView!.value));
   });
   it("throws an error message if the view doesn't return the needed properties", () => {
     if (!supportsProxy) {


### PR DESCRIPTION
If `element` is an input element then the current content of the input can be accessed as the property `element.value`. So maybe it would make sense to rename the `inputValue` output behavior to simply `value`? It is also shorter.