### PR TITLE
Add view function

### DIFF
--- a/examples/todo/src/TodoFooter.ts
+++ b/examples/todo/src/TodoFooter.ts
@@ -1,5 +1,5 @@
 import { Behavior, Stream, moment, combine } from "@funkia/hareactive";
-import { elements, modelView, fgo } from "../../../src";
+import { elements, modelView, view, fgo } from "../../../src";
 const { span, button, ul, li, a, footer, strong } = elements;
 import { navigate, Router, routePath } from "@funkia/rudolph";
 
@@ -16,51 +16,45 @@ export type Out = {
 };
 
 type FromView = {
-  filterBtnAll: Stream<any>;
-  filterBtnActive: Stream<any>;
-  filterBtnCompleted: Stream<any>;
-  clearCompleted: Stream<any>;
+  selectAll: Stream<string>;
+  selectActive: Stream<string>;
+  selectCompleted: Stream<string>;
+  clearCompleted: Stream<unknown>;
 };
 
 const isEmpty = (list: any[]) => list.length === 0;
 const formatRemainer = (value: number) => ` item${value === 1 ? "" : "s"} left`;
 
 const filterItem = (name: string, selectedClass: Behavior<string>) =>
-  li(
-    a(
-      {
-        style: {
-          cursor: "pointer"
+  view(
+    li(
+      a(
+        {
+          style: {
+            cursor: "pointer"
+          },
+          class: {
+            selected: selectedClass.map((s) => s === name)
+          }
         },
-        class: {
-          selected: selectedClass.map((s) => s === name)
-        }
-      },
-      name
-    ).output({
-      [`filterBtn${name}`]: "click"
-    })
+        name
+      ).output({ click: "click" })
+    )
   );
 
-const model = function*(
-  {
-    filterBtnActive,
-    filterBtnAll,
-    filterBtnCompleted,
-    clearCompleted
-  }: FromView,
+function* todoFooterModel(
+  { selectAll, selectActive, selectCompleted, clearCompleted }: FromView,
   { router }: { router: Router }
 ) {
-  const navs = combine(
-    filterBtnAll.mapTo("all"),
-    filterBtnActive.mapTo("active"),
-    filterBtnCompleted.mapTo("completed")
-  );
+  const navs = combine(selectAll, selectActive, selectCompleted);
   yield navigate(router, navs);
   return { clearCompleted };
-};
+}
 
-const view = ({  }: Out, { router, todosB, areAnyCompleted }: Params) => {
+const todoFooterView = (
+  {  }: Out,
+  { router, todosB, areAnyCompleted }: Params
+) => {
   const hidden = todosB.map(isEmpty);
   const itemsLeft = moment(
     (at) => at(todosB).filter((t) => !at(t.completed)).length
@@ -81,9 +75,15 @@ const view = ({  }: Out, { router, todosB, areAnyCompleted }: Params) => {
       itemsLeft.map(formatRemainer)
     ]),
     ul({ class: "filters" }, [
-      filterItem("All", selectedClass),
-      filterItem("Active", selectedClass),
-      filterItem("Completed", selectedClass)
+      filterItem("All", selectedClass).output((o) => ({
+        selectAll: o.click.mapTo("all")
+      })),
+      filterItem("Active", selectedClass).output((o) => ({
+        selectActive: o.click.mapTo("all")
+      })),
+      filterItem("Completed", selectedClass).output((o) => ({
+        selectCompleted: o.click.mapTo("completed")
+      }))
     ]),
     button(
       {
@@ -97,6 +97,9 @@ const view = ({  }: Out, { router, todosB, areAnyCompleted }: Params) => {
   ]);
 };
 
-const todoFooter = modelView<Out, FromView, Params>(fgo(model), view);
+const todoFooter = modelView<Out, FromView, Params>(
+  fgo(todoFooterModel),
+  todoFooterView
+);
 
 export default todoFooter;

--- a/examples/todo/src/TodoFooter.ts
+++ b/examples/todo/src/TodoFooter.ts
@@ -79,7 +79,7 @@ const todoFooterView = (
         selectAll: o.click.mapTo("all")
       })),
       filterItem("Active", selectedClass).output((o) => ({
-        selectActive: o.click.mapTo("all")
+        selectActive: o.click.mapTo("active")
       })),
       filterItem("Completed", selectedClass).output((o) => ({
         selectCompleted: o.click.mapTo("completed")

--- a/src/component.ts
+++ b/src/component.ts
@@ -78,6 +78,9 @@ export abstract class Component<O, A> implements Monad<A> {
       );
     }
   }
+  view(): Component<{}, O> {
+    return view(this);
+  }
   static multi: boolean = false;
   multi: boolean = false;
   abstract run(
@@ -318,13 +321,13 @@ class ModelViewComponent<M extends ReactivesObject, V> extends Component<
   constructor(
     private args: any[],
     private model: (...as: any[]) => Now<M>,
-    private view: (...as: any[]) => Child<V>,
+    private viewF: (...as: any[]) => Child<V>,
     private placeholderNames?: string[]
   ) {
     super();
   }
   run(parent: DomApi, destroyed: Future<boolean>): Out<{}, M> {
-    const { view, model, args } = this;
+    const { viewF, model, args } = this;
     let placeholders: any;
     if (supportsProxy) {
       placeholders = new Proxy({}, placeholderProxyHandler);
@@ -337,11 +340,11 @@ class ModelViewComponent<M extends ReactivesObject, V> extends Component<
       }
     }
     const { explicit: viewOutput } = toComponent(
-      view(placeholders, ...args)
+      viewF(placeholders, ...args)
     ).run(parent, destroyed);
     const helpfulViewOutput = addErrorHandler(
       model.name,
-      view.name,
+      viewF.name,
       Object.assign(viewOutput, { destroyed })
     );
     const behaviors = runNow(model(helpfulViewOutput, ...args));

--- a/test/component.spec.ts
+++ b/test/component.spec.ts
@@ -12,6 +12,7 @@ import {
   toComponent,
   Component,
   modelView,
+  view,
   emptyComponent,
   elements,
   loop,
@@ -341,6 +342,16 @@ describe("modelView", () => {
     destroy(true);
     expect(dom.querySelector("span")).to.not.exist;
     expect(toplevel).to.equal(true);
+  });
+});
+
+describe("view", () => {
+  it("turns selected output into available output", () => {
+    const obj = { a: 0, b: 1 };
+    const c = view(Component.of(obj).output((o) => o));
+    const { out, explicit } = testComponent(c);
+    expect(explicit).to.deep.equal({});
+    expect(out).to.deep.equal(obj);
   });
 });
 

--- a/test/component.spec.ts
+++ b/test/component.spec.ts
@@ -346,9 +346,17 @@ describe("modelView", () => {
 });
 
 describe("view", () => {
+  const obj = { a: 0, b: 1 };
   it("turns selected output into available output", () => {
-    const obj = { a: 0, b: 1 };
     const c = view(Component.of(obj).output((o) => o));
+    const { out, explicit } = testComponent(c);
+    expect(explicit).to.deep.equal({});
+    expect(out).to.deep.equal(obj);
+  });
+  it("is available as method", () => {
+    const c = Component.of(obj)
+      .output((o) => o)
+      .view();
     const { out, explicit } = testComponent(c);
     expect(explicit).to.deep.equal({});
     expect(out).to.deep.equal(obj);


### PR DESCRIPTION
This PR is an attempt at addressing a problem pointed out by @deklanw in #107.

The issue is that the TodoMVC example contains a `filterItem` function for creating a button in a list. Since this list item should tell its parent when it's being clicked it calls `output` on the `a` element in it. However, to prevent the outputs from all the constructed `filterItem`s from colliding the function takes a string and uses that string to change the property name of the outputted stream.

This causes two problems:
* It doesn't type check.
* When looking at the code in `todoFooterView` it is not apparent that `filterItem` provides any output since `output` is not called on its result. In a sense the output selected in `todoFooterView` "bubbles" two function levels up. This makes it hard to figure out where the output is actually coming from.

This PR fixes the problem by adding a `view` function. The idea is that `view` is like `modelView` without a model. Functions like `filterItem` should be considered custom components, but, since they don't have a model they should use `view` instead of `modelView`.

The only thing `view` does is that it turns a `Component<O, any>` into a `Component<{}, O>`. In other words, it unselects output by turning selected output into available output. Thus, by wrapping a component in `view` the selected output in that component doesn't "bubble" further up unless the parent makes it selected again by calling `output`.

I've adapted the TodoMVC example to use the `view` function.

I also propose that we consider it bad practice for a function to return a component which has already selected output. A function should always return a component with no selected output (just like `modelView` does) such that it becomes the callers job to select output and to prevent that output "bubbles" several layers up which makes it hard to track where things come from.

I would love to hear your opinion on this @deklanw.