### PR TITLE
New component function, refactor TodoMVC

### DIFF
--- a/examples/counters/src/version2.ts
+++ b/examples/counters/src/version2.ts
@@ -1,41 +1,32 @@
 import { Behavior, accum, Stream, combine } from "@funkia/hareactive";
-import { elements, modelView, fgo } from "../../../src";
+import { elements, fgo, component } from "../../../src";
 const { div, button } = elements;
 
-type CounterModelInput = {
+type On = {
   incrementClick: Stream<any>;
   decrementClick: Stream<any>;
 };
 
-type CounterViewInput = {
-  count: Behavior<number>;
-};
+const counter = component<On>(
+  fgo(function*({ incrementClick, decrementClick }) {
+    const increment = incrementClick.mapTo(1);
+    const decrement = decrementClick.mapTo(-1);
+    const changes = combine(increment, decrement);
+    const count = yield accum((n, m) => n + m, 0, changes);
 
-const counterModel = fgo(function*({
-  incrementClick,
-  decrementClick
-}: CounterModelInput) {
-  const increment = incrementClick.mapTo(1);
-  const decrement = decrementClick.mapTo(-1);
-  const changes = combine(increment, decrement);
-  const count = yield accum((n, m) => n + m, 0, changes);
-  return { count };
-});
+    return div([
+      "Counter ",
+      count,
+      " ",
+      button({ class: "btn btn-default" }, " + ").output({
+        incrementClick: "click"
+      }),
+      " ",
+      button({ class: "btn btn-default" }, " - ").output({
+        decrementClick: "click"
+      })
+    ]);
+  })
+);
 
-const counterView = ({ count }: CounterViewInput) =>
-  div([
-    "Counter ",
-    count,
-    " ",
-    button({ class: "btn btn-default" }, " + ").output({
-      incrementClick: "click"
-    }),
-    " ",
-    button({ class: "btn btn-default" }, " - ").output({
-      decrementClick: "click"
-    })
-  ]);
-
-const counter = modelView(counterModel, counterView);
-
-export const main2 = counter();
+export const main2 = counter;

--- a/examples/counters/src/version3.ts
+++ b/examples/counters/src/version3.ts
@@ -2,13 +2,12 @@ import {
   Behavior,
   combine,
   map,
-  Now,
   accum,
   scan,
   Stream
 } from "@funkia/hareactive";
 
-import { elements, fgo, list, ModelReturn, modelView } from "../../../src";
+import { elements, fgo, list, component } from "../../../src";
 const { br, div, button, h1, ul } = elements;
 
 const add = (n: number, m: number) => n + m;
@@ -19,76 +18,57 @@ type CounterModelInput = {
   decrementClick: Stream<any>;
 };
 
-type CounterViewInput = {
-  count: Behavior<number>;
-};
-
 type CounterOutput = {
   count: Behavior<number>;
 };
 
-const counterModel = fgo(function*({
-  incrementClick,
-  decrementClick
-}: CounterModelInput): ModelReturn<CounterViewInput> {
-  const increment = incrementClick.mapTo(1);
-  const decrement = decrementClick.mapTo(-1);
-  const count = yield accum(add, 0, combine(increment, decrement));
-  return { count };
-});
+const counter = () =>
+  component<CounterModelInput, CounterOutput>(
+    fgo(function*(on) {
+      const increment = on.incrementClick.mapTo(1);
+      const decrement = on.decrementClick.mapTo(-1);
+      const count = yield accum(add, 0, combine(increment, decrement));
 
-const counterView = ({ count }: CounterViewInput) =>
-  div([
-    "Counter ",
-    count,
-    " ",
-    button({ class: "btn btn-default" }, " + ").output({
-      incrementClick: "click"
-    }),
-    " ",
-    button({ class: "btn btn-default" }, " - ").output({
-      decrementClick: "click"
+      return div([
+        "Counter ",
+        count,
+        " ",
+        button({ class: "btn btn-default" }, " + ").output({
+          incrementClick: "click"
+        }),
+        " ",
+        button({ class: "btn btn-default" }, " - ").output({
+          decrementClick: "click"
+        })
+      ]).result({ count });
     })
-  ]);
+  );
 
-const counter = modelView(counterModel, counterView);
-
-type ViewInput = {
-  counterIds: Behavior<number[]>;
-  sum: Behavior<number>;
-};
-
-type ModelInput = {
+type ListOn = {
   addCounter: Stream<Event>;
-  listOut: Behavior<CounterOutput[]>;
 };
 
-const counterListModel = fgo(function*({
-  addCounter,
-  listOut
-}: ModelInput): Iterator<Now<any>> {
-  const nextId: Stream<number> = yield scan(add, 2, addCounter.mapTo(1));
-  const appendCounterFn = map(
-    (id) => (ids: number[]) => ids.concat([id]),
-    nextId
-  );
-  const counterIds = yield accum<(a: number[]) => number[], number[]>(
-    apply,
-    [0],
-    appendCounterFn
-  );
-  return { counterIds };
-});
+const counterList = component<ListOn>(
+  fgo(function*({ addCounter }) {
+    const nextId: Stream<number> = yield scan(add, 2, addCounter.mapTo(1));
+    const appendCounterFn = map(
+      (id) => (ids: number[]) => ids.concat([id]),
+      nextId
+    );
+    const counterIds = yield accum<(a: number[]) => number[], number[]>(
+      apply,
+      [0],
+      appendCounterFn
+    );
+    return [
+      h1("Counters"),
+      button({ class: "btn btn-primary" }, "Add counter").output({
+        addCounter: "click"
+      }),
+      br,
+      ul(list(counter, counterIds))
+    ];
+  })
+);
 
-const counterListView = ({ sum, counterIds }: ViewInput) => [
-  h1("Counters"),
-  button({ class: "btn btn-primary" }, "Add counter").output({
-    addCounter: "click"
-  }),
-  br,
-  ul(list(counter, counterIds).output((o) => ({ listOut: o })))
-];
-
-const counterList = modelView(counterListModel, counterListView);
-
-export const main3 = counterList();
+export const main3 = counterList;

--- a/examples/counters/src/version4.ts
+++ b/examples/counters/src/version4.ts
@@ -1,6 +1,4 @@
-import { foldr, lift, flatten } from "@funkia/jabz";
 import {
-  Now,
   Behavior,
   scan,
   Stream,
@@ -8,10 +6,11 @@ import {
   map,
   accum,
   shiftCurrent,
-  empty
+  empty,
+  moment
 } from "@funkia/hareactive";
 
-import { modelView, list, elements, fgo } from "../../../src";
+import { list, elements, fgo, component } from "../../../src";
 const { ul, li, p, br, button, h1 } = elements;
 
 const add = (n: number, m: number) => n + m;
@@ -20,10 +19,6 @@ const apply = <A>(f: (a: A) => A, a: A) => f(a);
 // Counter
 
 type Id = number;
-
-type CounterModelOut = {
-  count: Behavior<number>;
-};
 
 type CounterModelInput = {
   incrementClick: Stream<any>;
@@ -36,93 +31,76 @@ type CounterOutput = {
   deleteS: Stream<Id>;
 };
 
-const counterModel = fgo(function*(
-  { incrementClick, decrementClick, deleteClick }: CounterModelInput,
-  id: Id
-) {
-  const increment = incrementClick.mapTo(1);
-  const decrement = decrementClick.mapTo(-1);
-  const deleteS = deleteClick.mapTo(id);
-  const count = yield accum(add, 0, combine(increment, decrement));
-  return { count, deleteS };
-});
+const counter = (id: Id) =>
+  component<CounterModelInput>(
+    fgo(function*({ incrementClick, decrementClick, deleteClick }) {
+      const increment = incrementClick.mapTo(1);
+      const decrement = decrementClick.mapTo(-1);
+      const deleteS = deleteClick.mapTo(id);
+      const count = yield accum(add, 0, combine(increment, decrement));
 
-function counterView({ count }: CounterModelOut) {
-  return li([
-    "Counter ",
-    count,
-    " ",
-    button({ class: "btn btn-default" }, " + ").output({
-      incrementClick: "click"
-    }),
-    " ",
-    button({ class: "btn btn-default" }, " - ").output({
-      decrementClick: "click"
-    }),
-    " ",
-    button({ class: "btn btn-default" }, "x").output({
-      deleteClick: "click"
+      return li([
+        "Counter ",
+        count,
+        " ",
+        button({ class: "btn btn-default" }, " + ").output({
+          incrementClick: "click"
+        }),
+        " ",
+        button({ class: "btn btn-default" }, " - ").output({
+          decrementClick: "click"
+        }),
+        " ",
+        button({ class: "btn btn-default" }, "x").output({
+          deleteClick: "click"
+        })
+      ]).result({ count, deleteS });
     })
-  ]);
-}
-
-const counter = modelView(counterModel, counterView);
-
-type ToView = {
-  counterIds: Behavior<number[]>;
-  sum: Behavior<number>;
-};
+  );
 
 type ToModel = {
   addCounter: Stream<Event>;
   listOut: Behavior<CounterOutput[]>;
 };
 
-const mainModel = fgo(function*({
-  addCounter,
-  listOut
-}: ToModel): Iterator<Now<any>> {
-  const removeIdB = listOut.map((l) =>
-    l.length > 0 ? combine(...l.map((o) => o.deleteS)) : <Stream<number>>empty
-  );
-  const sum = <Behavior<number>>(
-    flatten(
-      map(
-        (list) =>
-          foldr(
-            ({ count }, sum) => lift(add, count, sum),
-            Behavior.of(0),
-            list
-          ),
-        listOut
+const counterList = component<ToModel>(
+  fgo(function*({ addCounter, listOut }) {
+    const removeIdB = listOut.map((l) =>
+      l.length > 0 ? combine(...l.map((o) => o.deleteS)) : <Stream<number>>empty
+    );
+    const sum = moment((at) =>
+      at(listOut)
+        .map((t) => at(t.count))
+        .reduce(add, 0)
+    );
+    const removeCounterIdFn = shiftCurrent(removeIdB).map(
+      (id) => (arr: number[]) => arr.filter((i) => i !== id)
+    );
+    const nextId: Stream<number> = yield scan(add, 2, addCounter.mapTo(1));
+    const appendCounterFn = map(
+      (id) => (ids: Id[]) => ids.concat([id]),
+      nextId
+    );
+    const modifications = combine(appendCounterFn, removeCounterIdFn);
+    const counterIds: Behavior<number[]> = yield accum(
+      apply,
+      [0, 1, 2],
+      modifications
+    );
+    return [
+      h1("Counters"),
+      p(["Sum ", sum]),
+      button({ class: "btn btn-primary" }, "Add counter").output({
+        addCounter: "click"
+      }),
+      br,
+      ul(
+        list((n) => counter(n).output((o) => o), counterIds).output((o) => ({
+          listOut: o
+        }))
       )
-    )
-  );
-  const removeCounterIdFn = shiftCurrent(removeIdB).map(
-    (id) => (arr: number[]) => arr.filter((i) => i !== id)
-  );
-  const nextId: Stream<number> = yield scan(add, 2, addCounter.mapTo(1));
-  const appendCounterFn = map((id) => (ids: Id[]) => ids.concat([id]), nextId);
-  const modifications = combine(appendCounterFn, removeCounterIdFn);
-  const counterIds = yield accum(apply, [0, 1, 2], modifications);
-  return { counterIds, sum };
-});
+    ];
+  })
+);
 
-const counterListView = ({ sum, counterIds }: ToView) => [
-  h1("Counters"),
-  p(["Sum ", sum]),
-  button({ class: "btn btn-primary" }, "Add counter").output({
-    addCounter: "click"
-  }),
-  br,
-  ul(
-    list((n) => counter(n).output((o) => o), counterIds).output((o) => ({
-      listOut: o
-    }))
-  )
-];
-
-export const counterList = modelView<ToView, ToModel>(
-  mainModel,
-  counterListView
-)();
+export const main4 = counterList;

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -1,20 +1,18 @@
-import { map, Now, Behavior } from "@funkia/hareactive";
-import { elements, modelView, runComponent } from "../../src";
+import { elements, runComponent, component } from "../../src";
+import { Behavior } from "@funkia/hareactive";
 const { span, input, div } = elements;
 
 const isValidEmail = (s: string) => /.+@.+\..+/i.test(s);
 
-const model = ({ email }: { email: Behavior<string> }) => {
-  const isValid = email.map(isValidEmail);
-  return Now.of({ isValid });
-};
+type On = { email: Behavior<string> };
 
-const view = ({ isValid }: { isValid: Behavior<boolean> }) => [
-  span("Please enter an email address: "),
-  input().output({ email: "value" }),
-  div(["The address is ", map((b) => (b ? "valid" : "invalid"), isValid)])
-];
+const app = component<On>((on) => {
+  const isValid = on.email.map(isValidEmail);
+  return [
+    span("Please enter an email address: "),
+    input().output({ email: "value" }),
+    div(["The address is ", isValid.map((b) => (b ? "valid" : "invalid"))])
+  ];
+});
 
-const app = modelView(model, view);
-
-runComponent("#mount", app());
+runComponent("#mount", app);

--- a/examples/todo/src/Item.ts
+++ b/examples/todo/src/Item.ts
@@ -1,186 +1,126 @@
 import { combine } from "@funkia/jabz";
-import {
-  Behavior,
-  changes,
-  filter,
-  keepWhen,
-  performStream,
-  sample,
-  snapshot,
-  stepper,
-  Stream,
-  lift,
-  toggle
-} from "@funkia/hareactive";
-
-import { modelView, elements, fgo, Component } from "../../../src";
+import * as H from "@funkia/hareactive";
+import { elements, fgo, component } from "../../../src";
 const { div, li, input, label, button, checkbox } = elements;
 
 import { setItemIO, itemBehavior, removeItemIO } from "./localstorage";
 
 const enter = 13;
 const esc = 27;
-const isKey = (keyCode: number) => (ev: { keyCode: number }) =>
-  ev.keyCode === keyCode;
-export const itemIdToPersistKey = (id: number) => `todoItem:${id}`;
-export const itemOutputToId = ({ id }: Output) => id;
 
-export type Item = {
-  taskName: Behavior<string>;
-  isComplete: Behavior<boolean>;
-};
-
-export type PersistedItem = {
-  taskName: string;
-  isComplete: boolean;
-};
-
-export type Input = {
+export type Props = {
   name: string;
   id: number;
-  toggleAll: Stream<boolean>;
-  currentFilter: Behavior<string>;
+  toggleAll: H.Stream<boolean>;
+  currentFilter: H.Behavior<string>;
 };
 
 type FromView = {
-  toggleTodo: Stream<boolean>;
-  taskName: Behavior<string>;
-  startEditing: Stream<any>;
-  nameBlur: Stream<any>;
-  deleteClicked: Stream<any>;
-  nameKeyup: Stream<any>;
-  newNameInput: Stream<any>;
+  toggleTodo: H.Stream<boolean>;
+  taskName: H.Behavior<string>;
+  startEditing: H.Stream<any>;
+  nameBlur: H.Stream<any>;
+  deleteClicked: H.Stream<any>;
+  cancel: H.Stream<any>;
+  enter: H.Stream<any>;
+  newNameInput: H.Stream<any>;
 };
 
 export type Output = {
-  taskName: Behavior<string>;
-  isComplete: Behavior<boolean>;
-  newName: Behavior<string>;
-  isEditing: Behavior<boolean>;
-  focusInput: Stream<any>;
-  hidden: Behavior<boolean>;
-  destroyItemId: Stream<number>;
-  completed: Behavior<boolean>;
+  destroyItemId: H.Stream<number>;
+  completed: H.Behavior<boolean>;
   id: number;
 };
 
-const itemModel = fgo(function*(
-  {
-    toggleTodo,
-    startEditing,
-    nameBlur,
-    deleteClicked,
-    nameKeyup,
-    newNameInput,
-    taskName
-  }: FromView,
-  { toggleAll, name: initialName, id, currentFilter }: Input
-): any {
-  const enterPress = filter(isKey(enter), nameKeyup);
-  const enterNotPressed = yield toggle(true, startEditing, enterPress);
-  const cancel = filter(isKey(esc), nameKeyup);
-  const notCancelled = yield toggle(true, startEditing, cancel);
-  const stopEditing = combine(
-    enterPress,
-    keepWhen(nameBlur, enterNotPressed),
-    cancel
+export default (props: Props) =>
+  component<FromView, Output>(
+    fgo(function*(on) {
+      const enterNotPressed = yield H.toggle(true, on.startEditing, on.enter);
+      const notCancelled = yield H.toggle(true, on.startEditing, on.cancel);
+      const stopEditing = combine(
+        on.enter,
+        H.keepWhen(on.nameBlur, enterNotPressed),
+        on.cancel
+      );
+      const editing = yield H.toggle(false, on.startEditing, stopEditing);
+      const newName = yield H.stepper(
+        props.name,
+        combine(
+          on.newNameInput.map((ev) => ev.target.value),
+          H.snapshot(on.taskName, on.cancel)
+        )
+      );
+      const nameChange = H.snapshot(
+        newName,
+        H.keepWhen(stopEditing, notCancelled)
+      );
+
+      // Restore potentially persisted todo item
+      const persistKey = "todoItem:" + props.id;
+      const savedItem = yield H.sample(itemBehavior(persistKey));
+      const initial =
+        savedItem === null
+          ? { taskName: props.name, completed: false }
+          : savedItem;
+
+      // Initialize task to restored values
+      const taskName: H.Behavior<string> = yield H.stepper(
+        initial.taskName,
+        nameChange
+      );
+      const completed: H.Behavior<boolean> = yield H.stepper(
+        initial.completed,
+        combine(on.toggleTodo, props.toggleAll)
+      );
+
+      // Persist todo item
+      const item = H.lift(
+        (taskName, completed) => ({ taskName, completed }),
+        taskName,
+        completed
+      );
+      yield H.performStream(
+        H.changes(item).map((i) => setItemIO(persistKey, i))
+      );
+
+      const destroyItem = combine(
+        on.deleteClicked,
+        nameChange.filter((s) => s === "")
+      );
+      const destroyItemId = destroyItem.mapTo(props.id);
+
+      // Remove persist todo item
+      yield H.performStream(destroyItem.mapTo(removeItemIO(persistKey)));
+
+      const hidden = H.lift(
+        (complete, filter) =>
+          (filter === "completed" && !complete) ||
+          (filter === "active" && complete),
+        completed,
+        props.currentFilter
+      );
+
+      return li({ class: ["todo", { completed, editing, hidden }] }, [
+        div({ class: "view" }, [
+          checkbox({
+            class: "toggle",
+            props: { checked: completed }
+          }).output({ toggleTodo: "checkedChange" }),
+          label(taskName).output({ startEditing: "dblclick" }),
+          button({ class: "destroy" }).output({ deleteClicked: "click" })
+        ]),
+        input({
+          class: "edit",
+          value: taskName,
+          actions: { focus: on.startEditing }
+        }).output((o) => ({
+          newNameInput: o.input,
+          nameBlur: o.blur,
+          enter: o.keyup.filter((ev) => ev.keyCode === enter),
+          cancel: o.keyup.filter((ev) => ev.keyCode === esc)
+        }))
+      ])
+        .output(() => ({ taskName }))
+        .result({ destroyItemId, completed, id: props.id });
+    })
   );
-  const isEditing = yield toggle(false, startEditing, stopEditing);
-  const newName = yield stepper(
-    initialName,
-    combine(
-      newNameInput.map((ev) => ev.target.value),
-      snapshot(taskName, cancel)
-    )
-  );
-  const nameChange = snapshot(newName, keepWhen(stopEditing, notCancelled));
-
-  // Restore potentially persisted todo item
-  const persistKey = itemIdToPersistKey(id);
-  const savedItem = yield sample(itemBehavior(persistKey));
-  const initial =
-    savedItem === null
-      ? { taskName: initialName, isComplete: false }
-      : savedItem;
-
-  // Initialize task to restored values
-  const taskName_: Behavior<string> = yield stepper(
-    initial.taskName,
-    nameChange
-  );
-  const isComplete: Behavior<boolean> = yield stepper(
-    initial.isComplete,
-    combine(toggleTodo, toggleAll)
-  );
-
-  // Persist todo item
-  const item = lift(
-    (taskName, isComplete) => ({ taskName, isComplete }),
-    taskName_,
-    isComplete
-  );
-  yield performStream(
-    changes(item).map((i: PersistedItem) => setItemIO(persistKey, i))
-  );
-
-  const destroyItem = combine(
-    deleteClicked,
-    nameChange.filter((s) => s === "")
-  );
-  const destroyItemId = destroyItem.mapTo(id);
-
-  // Remove persist todo item
-  yield performStream(destroyItem.mapTo(removeItemIO(persistKey)));
-
-  const hidden = lift(
-    (complete, filter) =>
-      (filter === "completed" && !complete) ||
-      (filter === "active" && complete),
-    isComplete,
-    currentFilter
-  );
-
-  return {
-    taskName: taskName_,
-    isComplete,
-    isEditing,
-    newName,
-    focusInput: startEditing,
-    id,
-    destroyItemId,
-    completed: isComplete,
-    hidden
-  };
-});
-
-function itemView(
-  { taskName, isComplete, isEditing, focusInput, hidden }: Output,
-  _: Input
-): Component<any, FromView> {
-  return li(
-    {
-      class: ["todo", { completed: isComplete, editing: isEditing, hidden }]
-    },
-    [
-      div({ class: "view" }, [
-        checkbox({
-          class: "toggle",
-          props: { checked: isComplete }
-        }).output({ toggleTodo: "checkedChange" }),
-        label(taskName).output({ startEditing: "dblclick" }),
-        button({ class: "destroy" }).output({ deleteClicked: "click" })
-      ]),
-      input({
-        class: "edit",
-        props: { value: taskName },
-        actions: { focus: focusInput }
-      }).output({
-        newNameInput: "input",
-        nameKeyup: "keyup",
-        nameBlur: "blur"
-      })
-    ]
-  ).output((o) => ({ taskName, ...o }));
-}
-
-export default modelView(itemModel, itemView);

--- a/examples/todo/src/TodoApp.ts
+++ b/examples/todo/src/TodoApp.ts
@@ -1,194 +1,159 @@
 import { fgo, sequence, IO, combine } from "@funkia/jabz";
-import {
-  Behavior,
-  sample,
-  snapshot,
-  Stream,
-  performStream,
-  changes,
-  lift,
-  snapshotWith,
-  accumCombine,
-  moment,
-  shiftCurrent,
-  empty
-} from "@funkia/hareactive";
-import { modelView, elements, list, output } from "../../../src";
+import * as H from "@funkia/hareactive";
+import { elements, list, component } from "../../../src";
 const { h1, p, header, footer, section, checkbox, ul, label } = elements;
-import { Router, routePath } from "@funkia/rudolph";
+import { locationHashB } from "@funkia/rudolph";
 
 import todoInput, { Out as InputOut } from "./TodoInput";
 import item, {
   Output as ItemOut,
-  Input as ItemParams,
+  Props as ItemParams,
   itemIdToPersistKey
 } from "./Item";
-import todoFooter, { Params as FooterParams } from "./TodoFooter";
+import todoFooter from "./TodoFooter";
 import { setItemIO, itemBehavior, removeItemIO } from "./localstorage";
 
 const isEmpty = (array: any[]) => array.length === 0;
 const includes = <A>(a: A, list: A[]) => list.indexOf(a) !== -1;
 
 type FromView = {
-  toggleAll: Stream<boolean>;
-  itemOutputs: Behavior<ItemOut[]>;
-  clearCompleted: Stream<{}>;
+  toggleAll: H.Stream<boolean>;
+  itemOutputs: H.Behavior<ItemOut[]>;
+  clearCompleted: H.Stream<{}>;
 } & InputOut;
-
-type ToView = {
-  toggleAll: Stream<boolean>;
-  todoNames: Behavior<ItemParams[]>;
-  itemOutputs: Behavior<ItemOut[]>;
-  areAllCompleted: Behavior<boolean>;
-} & FooterParams;
 
 // A behavior representing the current value of the localStorage property
 const todoListStorage = itemBehavior("todoList");
 
-function getCompletedIds(outputs: Behavior<ItemOut[]>): Behavior<number[]> {
-  return moment((at) => {
+const getCompletedIds = (outputs: H.Behavior<ItemOut[]>) =>
+  H.moment((at) => {
     return at(outputs)
       .filter((o) => at(o.completed))
       .map((o) => o.id);
   });
-}
 
 type ListModel<A, B> = {
-  prependItemS: Stream<A>;
-  removeKeyListS: Stream<B[]>;
+  prependItemS: H.Stream<A>;
+  removeKeyListS: H.Stream<B[]>;
   itemToKey: (a: A) => B;
   initial: A[];
 };
 
 // This model handles the modification of the list of Todos
-function listModel<A, B>({
-  prependItemS,
-  removeKeyListS,
-  itemToKey,
-  initial
-}: ListModel<A, B>) {
-  return accumCombine(
+function listModel<A, B>(props: ListModel<A, B>) {
+  return H.accumCombine(
     [
-      [prependItemS, (item, list) => [item].concat(list)],
+      [props.prependItemS, (item, list) => [item].concat(list)],
       [
-        removeKeyListS,
-        (keys, list) => list.filter((item) => !includes(itemToKey(item), keys))
+        props.removeKeyListS,
+        (keys, list) =>
+          list.filter((item) => !includes(props.itemToKey(item), keys))
       ]
     ],
-    initial
+    props.initial
   );
 }
 
-function* model({ addItem, toggleAll, clearCompleted, itemOutputs }: FromView) {
-  const nextId = itemOutputs.map(
-    (outs) => outs.reduce((maxId, { id }) => Math.max(maxId, id), 0) + 1
-  );
+export const app = component<FromView>(
+  fgo(function*(on) {
+    const nextId = on.itemOutputs.map(
+      (outs) => outs.reduce((maxId, { id }) => Math.max(maxId, id), 0) + 1
+    );
 
-  const newTodoS = snapshotWith((name, id) => ({ name, id }), nextId, addItem);
-  const deleteS = shiftCurrent(
-    itemOutputs.map((list) =>
-      list.length > 0 ? combine(...list.map((o) => o.destroyItemId)) : empty
-    )
-  );
-  const completedIds = getCompletedIds(itemOutputs);
-
-  const savedTodoName: ItemParams[] = yield sample(todoListStorage);
-  const restoredTodoName = savedTodoName === null ? [] : savedTodoName;
-
-  const clearCompletedIdS = snapshot(completedIds, clearCompleted);
-  const removeListS = combine(deleteS.map((a) => [a]), clearCompletedIdS);
-  const todoNames = yield listModel<{ id: number; name: string }, number>({
-    prependItemS: newTodoS,
-    removeKeyListS: removeListS,
-    itemToKey: ({ id }) => id,
-    initial: restoredTodoName
-  });
-
-  yield performStream(
-    clearCompletedIdS.map((ids) =>
-      sequence(IO, ids.map((id) => removeItemIO(itemIdToPersistKey(id))))
-    )
-  );
-  yield performStream(changes(todoNames).map((n) => setItemIO("todoList", n)));
-
-  const areAllCompleted = lift(
-    (currentIds, currentOuts) => currentIds.length === currentOuts.length,
-    completedIds,
-    itemOutputs
-  );
-  const areAnyCompleted = completedIds.map(isEmpty).map((b) => !b);
-
-  return {
-    itemOutputs,
-    todoNames,
-    clearAll: clearCompleted,
-    areAnyCompleted,
-    toggleAll,
-    areAllCompleted
-  };
-}
-
-function view(
-  {
-    itemOutputs,
-    todoNames,
-    areAnyCompleted,
-    toggleAll,
-    areAllCompleted
-  }: ToView,
-  router: Router
-) {
-  const currentFilter = routePath(
-    {
-      "/active": () => "active",
-      "/completed": () => "completed",
-      "*": () => ""
-    },
-    router
-  );
-  return [
-    section({ class: "todoapp" }, [
-      header({ class: "header" }, [
-        h1("todos"),
-        todoInput.output({ addItem: "addItem" })
-      ]),
-      section(
-        {
-          class: ["main", { hidden: todoNames.map(isEmpty) }]
-        },
-        [
-          checkbox({
-            class: "toggle-all",
-            attrs: { id: "toggle-all" },
-            props: { checked: areAllCompleted }
-          }).output({ toggleAll: "checkedChange" }),
-          label({ attrs: { for: "toggle-all" } }, "Mark all as complete"),
-          ul(
-            { class: "todo-list" },
-            list(
-              (n) =>
-                item({ toggleAll, currentFilter, ...n }).output({
-                  completed: "completed",
-                  destroyItemId: "destroyItemId",
-                  id: "id"
-                }),
-              todoNames,
-              (o) => o.id
-            ).output((o) => ({ itemOutputs: o }))
-          )
-        ]
-      ),
-      output(
-        { clearCompleted: "clearCompleted" },
-        todoFooter({ todosB: itemOutputs, areAnyCompleted, currentFilter })
+    const newTodoS = H.snapshotWith(
+      (name, id) => ({ name, id }),
+      nextId,
+      on.addItem
+    );
+    const deleteS = H.shiftCurrent(
+      on.itemOutputs.map((list) =>
+        list.length > 0 ? combine(...list.map((o) => o.destroyItemId)) : H.empty
       )
-    ]),
-    footer({ class: "info" }, [
-      p("Double-click to edit a todo"),
-      p("Written with Turbine"),
-      p("Part of TodoMVC")
-    ])
-  ];
-}
+    );
+    const completedIds = getCompletedIds(on.itemOutputs);
 
-export const app = modelView<ToView, FromView, Router>(fgo(model), view);
+    const savedTodoName: ItemParams[] = yield H.sample(todoListStorage);
+    const restoredTodoName = savedTodoName === null ? [] : savedTodoName;
+
+    const clearCompletedIdS = H.snapshot(completedIds, on.clearCompleted);
+    const removeListS = combine(deleteS.map((a) => [a]), clearCompletedIdS);
+    const todoNames = yield listModel<{ id: number; name: string }, number>({
+      prependItemS: newTodoS,
+      removeKeyListS: removeListS,
+      itemToKey: ({ id }) => id,
+      initial: restoredTodoName
+    });
+
+    yield H.performStream(
+      clearCompletedIdS.map((ids) =>
+        sequence(IO, ids.map((id) => removeItemIO(itemIdToPersistKey(id))))
+      )
+    );
+    yield H.performStream(
+      H.changes(todoNames).map((n) => setItemIO("todoList", n))
+    );
+
+    const areAllCompleted = H.lift(
+      (a, b) => a.length === b.length,
+      completedIds,
+      on.itemOutputs
+    );
+    const areAnyCompleted = completedIds.map(isEmpty).map((b) => !b);
+
+    // Strip the leading `/` from the hash location
+    const currentFilter = locationHashB.map((s) => s.slice(1));
+    const hidden = todoNames.map(isEmpty);
+
+    const itemsLeft = H.moment(
+      (at) => at(on.itemOutputs).filter((t) => !at(t.completed)).length
+    );
+
+    return [
+      section({ class: "todoapp" }, [
+        header({ class: "header" }, [
+          h1("todos"),
+          todoInput.output({ addItem: "addItem" })
+        ]),
+        section(
+          {
+            class: ["main", { hidden }]
+          },
+          [
+            checkbox({
+              class: "toggle-all",
+              attrs: { id: "toggle-all" },
+              props: { checked: areAllCompleted }
+            }).output({ toggleAll: "checkedChange" }),
+            label({ attrs: { for: "toggle-all" } }, "Mark all as complete"),
+            ul(
+              { class: "todo-list" },
+              list(
+                (n) =>
+                  item({ toggleAll: on.toggleAll, currentFilter, ...n }).output(
+                    {
+                      completed: "completed",
+                      destroyItemId: "destroyItemId",
+                      id: "id"
+                    }
+                  ),
+                todoNames,
+                (o) => o.id
+              ).output((o) => ({ itemOutputs: o }))
+            )
+          ]
+        ),
+        todoFooter({
+          itemsLeft,
+          areAnyCompleted,
+          currentFilter,
+          hidden
+        }).output({ clearCompleted: "clearCompleted" })
+      ]),
+      footer({ class: "info" }, [
+        p("Double-click to edit a todo"),
+        p("Written with Turbine"),
+        p("Part of TodoMVC")
+      ])
+    ];
+  })
+);

--- a/examples/todo/src/TodoFooter.ts
+++ b/examples/todo/src/TodoFooter.ts
@@ -1,67 +1,48 @@
-import { Behavior, Stream, moment } from "@funkia/hareactive";
+import * as H from "@funkia/hareactive";
 import { elements, view } from "../../../src";
 const { span, button, ul, li, a, footer, strong } = elements;
 
-import { Output as ItemOut } from "./Item";
-
-export type Params = {
-  currentFilter: Behavior<string>;
-  todosB: Behavior<ItemOut[]>;
-  areAnyCompleted: Behavior<boolean>;
+export type Props = {
+  currentFilter: H.Behavior<string>;
+  itemsLeft: H.Behavior<number>;
+  areAnyCompleted: H.Behavior<boolean>;
+  hidden: H.Behavior<boolean>;
 };
-
-export type Out = {
-  clearCompleted: Stream<any>;
-};
-
-const isEmpty = (list: any[]) => list.length === 0;
-const formatRemainer = (value: number) => ` item${value === 1 ? "" : "s"} left`;
 
 const filterItem = (
   name: string,
   path: string,
-  currentFilter: Behavior<string>
+  currentFilter: H.Behavior<string>
 ) =>
   view(
     li(
       a(
         {
           href: `#/${path}`,
-          class: {
-            selected: currentFilter.map((s) => s === path)
-          }
+          class: { selected: currentFilter.map((s) => s === path) }
         },
         name
       ).output({ click: "click" })
     )
   );
 
-const todoFooter = ({ currentFilter, todosB, areAnyCompleted }: Params) => {
-  const hidden = todosB.map(isEmpty);
-  const itemsLeft = moment(
-    (at) => at(todosB).filter((t) => !at(t.completed)).length
+const todoFooter = (props: Props) =>
+  view(
+    footer({ class: ["footer", { hidden: props.hidden }] }, [
+      span({ class: "todo-count" }, [
+        strong(props.itemsLeft),
+        props.itemsLeft.map((n) => ` item${n === 1 ? "" : "s"} left`)
+      ]),
+      ul({ class: "filters" }, [
+        filterItem("All", "", props.currentFilter),
+        filterItem("Active", "active", props.currentFilter),
+        filterItem("Completed", "completed", props.currentFilter)
+      ]),
+      button(
+        { class: ["clear-completed", { hidden: props.areAnyCompleted }] },
+        "Clear completed"
+      ).output({ clearCompleted: "click" })
+    ])
   );
-
-  return footer({ class: ["footer", { hidden }] }, [
-    span({ class: "todo-count" }, [
-      strong(itemsLeft),
-      itemsLeft.map(formatRemainer)
-    ]),
-    ul({ class: "filters" }, [
-      filterItem("All", "", currentFilter),
-      filterItem("Active", "active", currentFilter),
-      filterItem("Completed", "completed", currentFilter)
-    ]),
-    button(
-      {
-        style: {
-          visibility: areAnyCompleted.map((b) => (b ? "visible" : "hidden"))
-        },
-        class: "clear-completed"
-      },
-      "Clear completed"
-    ).output({ clearCompleted: "click" })
-  ]);
-};
 
 export default todoFooter;

--- a/examples/todo/src/index.ts
+++ b/examples/todo/src/index.ts
@@ -1,10 +1,5 @@
 import "todomvc-app-css/index.css";
 import { runComponent } from "../../../src";
 import { app } from "./TodoApp";
-import { createRouter } from "@funkia/rudolph";
 
-const router = createRouter({
-  useHash: true
-});
-
-runComponent("#mount", app(router));
+runComponent("#mount", app);

--- a/src/component.ts
+++ b/src/component.ts
@@ -88,7 +88,7 @@ export abstract class Component<A, O> implements Monad<O> {
     }
   }
   result<R>(o: R): Result<R, O> {
-    return { output: o, child: this };
+    return { available: o, child: this };
   }
   view(): Component<O, {}> {
     return view(this);
@@ -259,7 +259,7 @@ const placeholderProxyHandler = {
   }
 };
 
-type Result<R, O> = { output: R; child: Child<O> };
+type Result<R, O> = { available: R; child: Child<O> };
 
 function isLoopResult(r: any): r is Result<any, any> {
   return typeof r === "object" && "child" in r;
@@ -289,9 +289,9 @@ class LoopComponent<L, O> extends Component<O, {}> {
     }
     const res = this.f(placeholderObject);
     const result = Now.is(res) ? runNow<Child<L> | Result<O, L>>(res) : res;
-    const { output, child } = isLoopResult(result)
+    const { available, child } = isLoopResult(result)
       ? result
-      : { output: {} as O, child: result };
+      : { available: {} as O, child: result };
     const { output: looped } = toComponent(child).run(parent, destroyed);
     const needed = Object.keys(placeholderObject);
     for (const name of needed) {
@@ -303,7 +303,7 @@ class LoopComponent<L, O> extends Component<O, {}> {
       }
       placeholderObject[name].replaceWith(looped[name]);
     }
-    return { available: output, output: {} };
+    return { available, output: {} };
   }
 }
 

--- a/src/dom-builder.ts
+++ b/src/dom-builder.ts
@@ -1,4 +1,10 @@
-import { Behavior, Future, isBehavior, Stream } from "@funkia/hareactive";
+import {
+  Behavior,
+  Future,
+  isBehavior,
+  Stream,
+  isStream
+} from "@funkia/hareactive";
 import {
   behaviorFromEvent,
   streamFromEvent,
@@ -90,16 +96,17 @@ export type ClassDescription =
 export interface ClassDescriptionArray extends Array<ClassDescription> {}
 
 export type Attributes = {
-  [name: string]: (Showable | boolean) | Behavior<Showable | boolean>;
+  [name: string]:
+    | (Showable | boolean)
+    | Stream<Showable | boolean>
+    | Behavior<Showable | boolean>;
 };
 
 type _InitialProperties = {
   streams?: StreamDescriptions;
   behaviors?: BehaviorDescriptions;
   style?: Style;
-  props?: {
-    [name: string]: Showable | Behavior<Showable | boolean>;
-  };
+  props?: Attributes;
   attrs?: Attributes;
   actionDefinitions?: ActionDefinitions;
   actions?: Actions;
@@ -166,7 +173,7 @@ const styleSetter = (element: HTMLElement) => (key: string, value: string) =>
   (element.style[<any>key] = value);
 
 function handleObject<A>(
-  object: { [key: string]: A | Behavior<A> } | undefined,
+  object: { [key: string]: A | Behavior<A> | Stream<A> } | undefined,
   element: HTMLElement,
   createSetter: (element: HTMLElement) => (key: string, value: A) => void
 ): void {
@@ -176,6 +183,8 @@ function handleObject<A>(
       const value = object[key];
       if (isBehavior(value)) {
         render((newValue) => setter(key, newValue), value);
+      } else if (isStream(value)) {
+        value.subscribe((newValue) => setter(key, newValue));
       } else {
         setter(key, value);
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { isBehavior } from "@funkia/hareactive";
+import { isBehavior, isStream } from "@funkia/hareactive";
 
 function arrayConcat<A>(arr1: A[], arr2: A[]): A[] {
   const result = [];
@@ -12,7 +12,12 @@ function arrayConcat<A>(arr1: A[], arr2: A[]): A[] {
 }
 
 function isObject(item: any): item is Object {
-  return typeof item === "object" && !Array.isArray(item) && !isBehavior(item);
+  return (
+    typeof item === "object" &&
+    !Array.isArray(item) &&
+    !isBehavior(item) &&
+    !isStream(item)
+  );
 }
 
 export function mergeObj<A, B>(a: A, b: B): A & B {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,15 +20,26 @@ function isObject(item: any): item is Object {
   );
 }
 
-export function mergeObj<A, B>(a: A, b: B): A & B {
-  const c: { [key: string]: any } = {};
-  for (const key of Object.keys(a) as (keyof A & string)[]) {
-    c[key] = a[key];
+export function mergeObj<
+  A extends Record<string, any>,
+  B extends Record<string, any>
+>(a: A, b: B): A & B {
+  for (const key of Object.keys(b) as string[]) {
+    const valueA: any = a[key];
+    const valueB: any = b[key];
+    if (valueA !== undefined) {
+      if (isStream(valueA) && isStream(valueB)) {
+        (a as any)[key] = valueA.combine(valueB);
+      } else {
+        throw new Error(
+          `Components was merged with colliding output on key ${key}`
+        );
+      }
+    } else {
+      (a as any)[key] = valueB;
+    }
   }
-  for (const key of Object.keys(b) as (keyof B & string)[]) {
-    c[key] = b[key];
-  }
-  return <any>c;
+  return <any>a;
 }
 
 export type Merge<T> = { [K in keyof T]: T[K] };

--- a/test/component.spec.ts
+++ b/test/component.spec.ts
@@ -15,7 +15,7 @@ import {
   view,
   emptyComponent,
   elements,
-  loop,
+  component,
   testComponent,
   list,
   runComponent,
@@ -221,23 +221,26 @@ describe("component specs", () => {
     });
   });
 
-  describe("loop", () => {
+  describe("component loop", () => {
     type Looped = { name: H.Behavior<string>; destroyed: H.Future<boolean> };
     it("passed selected output as argument", () => {
       let b: H.Behavior<number> | undefined = undefined;
-      const comp = loop<{ foo: H.Behavior<number> }>((input) => {
+      const comp = component<
+        { foo: H.Behavior<number> },
+        { bar: H.Behavior<number> }
+      >((input) => {
         b = input.foo;
         return Component.of({
           foo: H.Behavior.of(2)
-        });
+        }).result({ bar: H.Behavior.of(3) });
       });
       const { available, output } = testComponent(comp);
       assert.deepEqual(Object.keys(output), []);
-      assert.deepEqual(Object.keys(available), ["foo"]);
+      assert.deepEqual(Object.keys(available), ["bar"]);
       expect(H.at(b!)).to.equal(2);
     });
     it("works with selected fgo and looped behavior", () => {
-      const comp = loop(
+      const comp = component(
         fgo(function*({ name }: Looped): IterableIterator<Component<any, any>> {
           yield div(name);
           ({ name } = yield input({ props: { value: "Foo" } }).output({
@@ -252,7 +255,7 @@ describe("component specs", () => {
     });
     it("can be told to destroy", () => {
       let toplevel = false;
-      const comp = loop(
+      const comp = component(
         fgo(function*({
           name,
           destroyed
@@ -273,7 +276,7 @@ describe("component specs", () => {
       expect(toplevel).to.equal(true);
     });
     it("throws helpful error is a reactive is missing", () => {
-      const c = loop((props: { foo: H.Behavior<string> }) => {
+      const c = component((props: { foo: H.Behavior<string> }) => {
         // Access something that isn't there
         (props as any).bar;
         return div([dynamic(props.foo)]).output((_) => ({

--- a/test/component.spec.ts
+++ b/test/component.spec.ts
@@ -34,7 +34,7 @@ describe("component specs", () => {
       let result: number | undefined = undefined;
       const c = performComponent(() => (result = 12));
       assert.strictEqual(result, undefined);
-      const { output, available } = testComponent(c);
+      const { output } = testComponent(c);
       assert.strictEqual(result, 12);
       assert.strictEqual(output, 12);
     });
@@ -98,7 +98,7 @@ describe("component specs", () => {
           newFoo: "foo",
           newBar: "bar"
         });
-      const { dom, available, output } = testComponent(comp);
+      const { available, output } = testComponent(comp);
       expect(output.newFoo).to.equal(1);
       expect(output.newBar).to.equal(2);
       expect((available as any).newFoo).to.be.undefined;

--- a/test/dom-builder.spec.ts
+++ b/test/dom-builder.spec.ts
@@ -308,6 +308,14 @@ describe("dom-builder", () => {
       push("/bar", hrefB);
       expect(aElm).to.have.attribute("href", "/bar");
     });
+    it("sets attributes from streams", () => {
+      const hrefS = sinkStream<string>();
+      const { dom } = testComponent(element("a", { attrs: { href: hrefS } })());
+      const aElm = dom.firstChild;
+      expect(aElm).to.not.have.attribute("href");
+      push("/bar", hrefS);
+      expect(aElm).to.have.attribute("href", "/bar");
+    });
     it("sets boolean attributes correctly", () => {
       const { dom } = testComponent(
         element("a", { attrs: { contenteditable: true } })()
@@ -354,6 +362,30 @@ describe("dom-builder", () => {
       expect(aElm.innerHTML).to.equal("<b>Hi</b>");
       push("<b>there</b>", htmlB);
       expect(aElm.innerHTML).to.equal("<b>there</b>");
+    });
+    it("sets properties from stream", () => {
+      const value = sinkStream<string>();
+      const { dom } = testComponent(element("input", { props: { value } })());
+      const inputElm = dom.firstChild! as HTMLInputElement;
+      assert.strictEqual(inputElm.value, "");
+      push("bar", value);
+      assert.strictEqual(inputElm.value, "bar");
+    });
+    it("sets properties from stream", () => {
+      const value = sinkStream<string>();
+      const { dom } = testComponent(element("input", { props: { value } })());
+      const inputElm = dom.firstChild! as HTMLInputElement;
+      assert.strictEqual(inputElm.value, "");
+      push("bar", value);
+      assert.strictEqual(inputElm.value, "bar");
+    });
+    it("sets input value from stream", () => {
+      const value = sinkStream<string>();
+      const { dom } = testComponent(element("input", { value })());
+      const inputElm = dom.firstChild! as HTMLInputElement;
+      assert.strictEqual(inputElm.value, "");
+      push("bar", value);
+      assert.strictEqual(inputElm.value, "bar");
     });
     it("sets input value", () => {
       const b = sinkBehavior("foo");


### PR DESCRIPTION
Renames `loop` to `component` and makes it handle a return value that allows setting the available output of the resulting component.

Updates the TodoMVC example to use `component` instead of `modelView` and refactors it to follow other, IMHO, best practices.

More than 100 lines of code shaved off in the TodoMVC.